### PR TITLE
Add `lib-openssl` to requirements.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.0",
+        "lib-openssl": "0.9.*"
     },
     "autoload": {
        "psr-0": { "ass\\XmlSecurity": "src/" }


### PR DESCRIPTION
Composer allows you to specify platform dependencies as well. I've added `lib-openssl` to requirements.

There is also an `ext-openssl` requirement but the version number seems to be `0` on my machine so that doesn't seem to valuable....
