### PR TITLE
Cannot install without ext-mcrypt even previous versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,11 @@
     ],
     "require": {
         "php": ">=5.3.0",
-        "ext-mcrypt": "*",
         "ext-openssl": "*",
         "lib-openssl": ">=0.9.0"
+    },
+    "suggest": {
+        "ext-mcrypt": ""
     },
     "autoload": {
        "psr-0": { "ass\\XmlSecurity": "src/" }


### PR DESCRIPTION
I tried to install the library using the commit hash when there wasn't ext-mcrypt dependency. But cannot do that because dependencies are taken from dev-master version.

I find two solutions:

1) tag the commit when there wasn't ext-mcrypt dependency
2) move ext-mcrypt to optional dependencies (am I right that it is optional?)

I've implemented the second option in this PR.
